### PR TITLE
fix(.gitignore): exclude report.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@
 **/*_s
 scripts/*
 !scripts/collect.sh
-!scripts/run-template.sh
+!scripts/report.py
 !scripts/gen_diff.py
 **/logs


### PR DESCRIPTION
We have excluded scripts by default, since report.py has been added, we should exclude this file in .gitignore.